### PR TITLE
Add setup tag to note where user configuration is required

### DIFF
--- a/.github/workflows/workshop_ci.yml
+++ b/.github/workflows/workshop_ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install az ml & set default values for AML
         run: | #setup: provide group, workspace and location
           az extension add -n ml -y --version 2.2.1
-          az configure --defaults group=azureml workspace=ws01ent location=westus2   
+          az configure --defaults group=azureml workspace=ws01ent location=westus2  #setup: provide your resource group name, workspace name, and location
       - name: run training and model validation
         run: |
          az ml job create -s -f src/workshop/core/pipelines/training_pipeline.yml


### PR DESCRIPTION
According to [`src/workshop/documents/part_4.md` -- Step 1](https://github.com/microsoft/MLOpsTemplate/blob/main/src/workshop/documents/part_4.md#steps), we can expect a `#setup` tag in `.github/workflows/workshop_ci.yml` everywhere that the user needs to make a configuration change. Unfortunately, this isn't true, since there's no `#setup` tag on line 35. This PR fixes that.